### PR TITLE
fix(media_control): avoid layout shift on visibility toggle

### DIFF
--- a/src/plugins/media_control/public/media-control.scss
+++ b/src/plugins/media_control/public/media-control.scss
@@ -27,6 +27,7 @@
     width: 100%;
     bottom: 0;
     background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
+    will-change: transform, opacity;
     transition: opacity 0.6s ease-out;
   }
 
@@ -52,7 +53,7 @@
       opacity: 0;
     }
     .media-control-layer[data-controls] {
-      bottom: -50px;
+      transform: translateY(50px);
       .bar-container[data-seekbar]{
         .bar-scrubber[data-seekbar] {
           opacity: 0;
@@ -63,7 +64,8 @@
 
   .media-control-layer[data-controls] {
     position: absolute;
-    bottom: 7px;
+    transform: translateY(-7px);
+    bottom: 0;
     width: 100%;
     height: 32px;
     font-size: 0;


### PR DESCRIPTION
The intention is to improve the user experience using new metrics explained at [https://web.dev/cls/](https://web.dev/cls/).

It can be validated inspecting the page: 
 - Go to "More Tools" and select "Rendering."
 - Select "Layout Shift Regions" 
It will show a blue rectangle over the area.

<img width="529" alt="Captura de Tela 2020-06-22 às 18 52 02" src="https://user-images.githubusercontent.com/770092/85340642-d47c7900-b4bc-11ea-8000-48ff92e28247.png">


It also can be validated against the performance tab on Chrome.
Should not change the behavior of the media control over browsers like: Firefox, Edge, Safari, and Brave

**Before:**
<img width="526" alt="Captura de Tela 2020-06-22 às 19 04 00" src="https://user-images.githubusercontent.com/770092/85340685-e6f6b280-b4bc-11ea-9d25-d80407587897.png">


**After:**
<img width="529" alt="Captura de Tela 2020-06-22 às 18 52 36" src="https://user-images.githubusercontent.com/770092/85340715-f4ac3800-b4bc-11ea-82fe-f174ee2e487d.png">
