### PR TITLE
Closed Captions - Simplify binds on the core instance

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
-java_script:
+eslint:
   enabled: true
-  config_file: .eslintrc.js
+  config_file: .eslintrc.json

--- a/src/plugins/closed_captions/closed_captions.js
+++ b/src/plugins/closed_captions/closed_captions.js
@@ -35,18 +35,11 @@ export default class ClosedCaptions extends UICorePlugin {
   }
 
   bindEvents() {
-    this.bindCoreEvents()
-    this.bindContainerEvents()
-  }
+    this.listenTo(this.core, Events.CORE_ACTIVE_CONTAINER_CHANGED, this.containerChanged)
+    this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_RENDERED, this.render)
+    this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_HIDE, this.hideContextMenu)
 
-  bindCoreEvents() {
-    if (this.core.mediaControl.settings) {
-      this.listenTo(this.core, Events.CORE_ACTIVE_CONTAINER_CHANGED, this.containerChanged)
-      this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_RENDERED, this.render)
-      this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_HIDE, this.hideContextMenu)
-    } else {
-      setTimeout(() => this.bindCoreEvents(), 100)
-    }
+    this.bindContainerEvents()
   }
 
   bindContainerEvents() {


### PR DESCRIPTION
## Summary

The delay to call `bindCoreEvents` when the `if` statement condition is not true causes the problem of not render the CC menu. This occurs because the delay used on the `else` statement makes some events that need to be registered with callbacks be missed.

This PR removes the unnecessary `if/else` statements to bind events on the core reference ASAP.

## Changes

* Move listeners on core instance to `bindEvents` method;
* Delete `bindCoreEvents` method;

## How to test

* Play one media with subtitles;
  * E.g.: `https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8`
* The CC menu should be rendered;

## A picture tells a thousand words

### Before this PR
![Screen Shot 2020-11-01 at 14 57 49](https://user-images.githubusercontent.com/5631063/97810493-095ec080-1c53-11eb-8e58-376c7bb21b00.png)

### After this PR
![Screen Shot 2020-11-01 at 14 59 41](https://user-images.githubusercontent.com/5631063/97810496-0d8ade00-1c53-11eb-9353-9a709c8d3ab2.png)
