### PR TITLE
Improved closed_captions compatibility with hlsjs-playback.

### DIFF
--- a/src/plugins/closed_captions/closed_captions.js
+++ b/src/plugins/closed_captions/closed_captions.js
@@ -96,13 +96,11 @@ export default class ClosedCaptions extends UICorePlugin {
   }
 
   setCurrentContextMenuElement(trackId) {
-    if (this._trackId !== trackId) {
-      this.contextMenuElement().removeClass('current')
-      this.contextMenuElement(trackId).addClass('current')
-      const method = trackId > -1 ? 'addClass' : 'removeClass'
-      this.$ccButton[method]('enabled')
-      this._trackId = trackId
-    }
+    this.contextMenuElement().removeClass('current')
+    this.contextMenuElement(trackId).addClass('current')
+    const method = trackId > -1 ? 'addClass' : 'removeClass'
+    this.$ccButton[method]('enabled')
+    this._trackId = trackId
   }
 
   renderCcButton() {
@@ -121,6 +119,9 @@ export default class ClosedCaptions extends UICorePlugin {
     this.$ccButton = this.$el.find('button.cc-button[data-cc-button]')
     this.$ccButton.append(ccIcon)
     this.$el.append(this.style)
+
+    if (this.container)
+      this.setCurrentContextMenuElement(this.container.closedCaptionsTrackId)
   }
 
   render() {

--- a/src/plugins/closed_captions/public/closed_captions.html
+++ b/src/plugins/closed_captions/public/closed_captions.html
@@ -5,6 +5,6 @@
   <% }; %>
   <li><a href="#" data-cc-select="-1"><%= disabledLabel %></a></li>
   <% for (var i = 0; i < tracks.length; i++) { %>
-    <li><a href="#" data-cc-select="<%= tracks[i].id %>"><%= tracks[i].label %></a></li>
+    <li><a href="#" data-cc-select="<%= tracks[i].id %>"><%= tracks[i].label %><%= tracks[i].attributes && tracks[i].attributes.forced ? ' (forced)' : '' %></a></li>
   <% }; %>
 </ul>


### PR DESCRIPTION
* Fixed sync issues between closed_captions GUI and actual backend state when using hlsjs-playback.
* closed_captions menu now renders track names with suffix ' (forced)' if indicated by an optional boolean field `tracks[i].attributes.forced` (currently only provided by hlsjs-playback via a pull request I made earlier ).

This PR is meant to go along with [my other PR in the hlsjs-playback repo](https://github.com/clappr/hlsjs-playback/pull/18) but can also provide some small benefit when used standalone.