### PR TITLE
Don't use "display: flex !important"

### DIFF
--- a/src/plugins/error_screen/public/error_screen.scss
+++ b/src/plugins/error_screen/public/error_screen.scss
@@ -10,14 +10,16 @@ div.player-error-screen {
   width: 100%;
   background-color: rgba(0, 0, 0, 0.7);
   z-index: 2000;
-  display: flex !important;
-  flex-direction: column;
-  justify-content: center;
 
   &__content[data-error-screen] {
     font-size: 14px;
     color: #CCCACA;
     margin-top: 45px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   &__title[data-error-screen] {


### PR DESCRIPTION
Here is a bug:

1. Play stream, got an error
2. Error screen being rendered and displayed with `display: flex !important;`
3. Start another stream with `configure()` or `load()`
4. Error screen was hidden with `display: none;` but still present because of `!important`

Removed `display: flex !important` and center error message with `position: absolute;` and `transform: translateY(-50%);`