### PR TITLE
Extend Click to Pause Plugin to accept options

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Adds the possibility to toggle between the `play`/`pause` playback states by cli
 ```javascript
 var player = new Clappr.Player({
   source: "http://your.video/here.mp4",
-  // not mandatory, use only if you need it
+  // Optionally, send a payload upon the container's pausing with the `onClickPayload` parameter
   clickToPauseConfig: { 
     onClickPayload: { any: 'any' } // sends the payload to container when clicked
 });

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ A plugin that renders the interface over the video container and add the possibi
 
 ### Click to pause
 Adds the possibility to toggle between the `play`/`pause` playback states by clicking on the container element.
+```javascript
+var player = new Clappr.Player({
+  source: "http://your.video/here.mp4",
+  // not mandatory, use only if you need it
+  clickToPauseConfig: { 
+    onClickPayload: { any: 'any' } // sends the payload to container when clicked
+});
+```
 
 ### Closed captions
 Adds the possibility to customize the label and title of the subtitles.

--- a/src/plugins/click_to_pause/click_to_pause.js
+++ b/src/plugins/click_to_pause/click_to_pause.js
@@ -7,6 +7,7 @@ import { ContainerPlugin, Events, Playback } from '@clappr/core'
 export default class ClickToPausePlugin extends ContainerPlugin {
   get name() { return 'click_to_pause' }
   get supportedVersion() { return { min: CLAPPR_CORE_VERSION } }
+  get config() { return this.container.options.clickToPauseConfig || {} }
 
   constructor(container) {
     super(container)
@@ -18,11 +19,13 @@ export default class ClickToPausePlugin extends ContainerPlugin {
   }
 
   click() {
+    const onClickPayload = this.config.onClickPayload
+
     if (this.container.getPlaybackType() !== Playback.LIVE || this.container.isDvrEnabled()) {
       if (this.container.isPlaying())
-        this.container.pause()
+        this.container.pause(onClickPayload)
       else
-        this.container.play()
+        this.container.play(onClickPayload)
 
     }
   }

--- a/src/plugins/click_to_pause/click_to_pause.test.js
+++ b/src/plugins/click_to_pause/click_to_pause.test.js
@@ -138,4 +138,45 @@ describe('clickToPause', function() {
       this.container.trigger(Events.CONTAINER_SETTINGSUPDATE)
     })
   })
+
+  it('call container play with parameters when received from config', function(done) {
+    this.container = new Container({
+      playback: this.playback,
+      clickToPauseConfig: { onClickPayload: { testing: true } }
+    })
+    const plugin = new ClickToPause(this.container) // eslint-disable-line
+
+
+    sinon.stub(this.container, 'isPlaying').callsFake(() => false)
+    sinon.stub(this.container, 'isDvrEnabled').callsFake(() => true)
+    sinon.spy(this.container, 'play')
+
+    this.container.on(Events.CONTAINER_CLICK, () => {
+      this.container.play.should.have.been.calledWith({ testing: true })
+      done()
+    })
+
+    this.container.trigger(Events.CONTAINER_CLICK)
+  })
+
+  it('call container pause with parameters when received from config', function(done) {
+    this.container = new Container({
+      playback: this.playback,
+      clickToPauseConfig: { onClickPayload: { testing: true } }
+    })
+    const plugin = new ClickToPause(this.container) // eslint-disable-line
+
+
+    sinon.stub(this.container, 'isPlaying').callsFake(() => true)
+    sinon.stub(this.container, 'isDvrEnabled').callsFake(() => true)
+    sinon.spy(this.container, 'pause')
+
+    this.container.on(Events.CONTAINER_CLICK, () => {
+      this.container.pause.should.have.been.calledWith({ testing: true })
+      done()
+    })
+
+    this.container.trigger(Events.CONTAINER_CLICK)
+  })
+
 })


### PR DESCRIPTION
## Summary

This PR allows the Click to Pause plugin to receive options and bridge to the container.

The option we need to set on player config are not mandatory:
```javascript
var player = new Clappr.Player({
  source: "http://your.video/here.mp4",
  clickToPauseConfig: { 
    onClickPayload: { any: 'any' }
});
```

## Changes

- `src/plugins/click_to_pause/click_to_pause.js`: Gets the option payload and send it to the Container
- `src/plugins/click_to_pause/click_to_pause.test.js`: Create tests for the plugin. 
- `README.md`: Update docs

## How to test

1. Run this PR
2. Set the configuration above on Clappr Config
3. On the Developer Tools, listen to Containers `play` or `pause`, and log his callback. Ex: `player.listenTo(player.core.activeContainer, Clappr.Events.CONTAINER_PAUSE, (...args) => console.log('Arguments: ', ...args))`
3. Use the Click to Pause plugin, by clicking on the video.
4. The Developer Tools should Output these arguments.