### PR TITLE
GitHub – Add Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+This PR implements / updates / fixes...
+
+<!-- Add a description of the changes made to your PR, as well as the context and motivation behind them.
+
+Please add, if appropriate, external links that make the PR easier to understand.
+-->
+
+## Changes
+
+- `archive_name1.js`:
+  - ...
+  - ...
+- `archive_name2.js`: ...
+
+## How to test
+
+1. ...
+1. ...
+1. ...
+
+## Images
+
+### Before this PR
+
+<!-- 
+Insert an image / gif / video showing the Player's original behavior. 
+If PR is a new feature, it's unnecessary to add.
+-->
+
+### After this PR
+
+<!-- Insert an image / gif / video showing the Player's behavior after the modifications -->


### PR DESCRIPTION
## Summary

This PR adds a template for new Pull Requests.

## Changes

- `.github/pull_request_template`: Added pull request template

## How to test

This PR doesn't affect Clappr. No tests required.